### PR TITLE
adds strikethrough support

### DIFF
--- a/dropplets/plugins/markdown.php
+++ b/dropplets/plugins/markdown.php
@@ -1432,8 +1432,7 @@ class Markdown_Parser {
 	}
 
 	function doStrikethroughs($text) {
-		$text = str_replace( ' ~~', ' <del>', $text );
-		$text = str_replace( '~~ ', '</del> ', $text );
+		$text = preg_replace(  '#~~(.+?)(?:~~)#is', '<del>$1</del>', $text );
 		return $text;
 	}
 


### PR DESCRIPTION
this is a quick hack to support `~~` for strikethroughs, e.g. ~~strike~~. The hack part comes into play if your ~~ is at the end of a line, like: ~~this is a strikethrough.~~

In that case, you need to add an extra space at the end of the line so the `str_replace` function sees `~~` and replaces it with a `</del>`. If I get better at crazy preg_match or preg_split or other regular expression functions like that, this should be updated to support it more natively. but for now, this is probably more of an edge case just for me, , this should be update Mou supports ~~ as Strikethroughs.

(this was originally pushed to my fork's master and got mixed in with the template stuff. created it's own fork so it can be merged into Dropplets master without the template changes)
