### PR TITLE
Fixes as per #34 and #35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.esproj
 .DS_Store
 dropplets/config.php
+dropplets/config/config-settings.php

--- a/dropplets/config/submit-settings.php
+++ b/dropplets/config/submit-settings.php
@@ -10,10 +10,10 @@ if($_POST['submit'] == "submit")
     $blog_email = $_POST['blog_email'];
     $blog_twitter = $_POST['blog_twitter'];
     $blog_url = $_POST['blog_url'];
-    $blog_title = addslashes($_POST['blog_title']);
-    $meta_description = addslashes($_POST['meta_description']);
-    $intro_title = addslashes($_POST['intro_title']);
-    $intro_text = addslashes($_POST['intro_text']);
+    $blog_title = htmlspecialchars($_POST['blog_title']);
+    $meta_description = htmlspecialchars($_POST['meta_description']);
+    $intro_title = htmlspecialchars($_POST['intro_title']);
+    $intro_text = htmlspecialchars($_POST['intro_text']);
     $password = $_POST['password'];
     
     // Output Stuff


### PR DESCRIPTION
Adds the new config file to the `.gitignore` (i've left the old one, no clue what you use it for... mind) and changes `addslashes` to `htmlspecialchars`. Testing on my deployment it looks fine, although you might get a sudden escaped character.

I would have kept `addslashes` but that would involve going through and adding `stripslashes` to everywhere, including templates.

![dropplets-issue](https://f.cloud.github.com/assets/653864/377775/9a2ca740-a4eb-11e2-99d1-ffb4abec5a17.png)
