### PR TITLE
Fixed spelling of 'sentence' in site meta description field placeholder ...

### DIFF
--- a/dropplets/settings.php
+++ b/dropplets/settings.php
@@ -46,7 +46,7 @@ $url = str_replace('/dropplets/index.php?filename=', '', $current_url);
     		    </div>
     		    
     		    <div class="input">
-    		        <textarea name="meta_description" id="meta_description" rows="6" required placeholder="Add your site description here... just a short sentance that describes what your blog is going to be about."></textarea>
+    		        <textarea name="meta_description" id="meta_description" rows="6" required placeholder="Add your site description here... just a short sentence that describes what your blog is going to be about."></textarea>
     		    </div> 
 		    </fieldset>
 		    


### PR DESCRIPTION
Just found a small typo while setting-up a blog with dropplets: 'sentence' was misspelled in dropplets/settings.php
