### PR TITLE
Settings submission permission check.

### DIFF
--- a/dropplets/config/submit-settings.php
+++ b/dropplets/config/submit-settings.php
@@ -1,5 +1,5 @@
 <?php
-
+session_start();
 $settings_file = "config-settings.php";
 $htaccess_file = "../../.htaccess";
 
@@ -18,9 +18,8 @@ function settings_format($name, $value) {
 
 // Should allow this only on first install or after the user is authenticated
 // but this doesn't quite work. So back to default.
-// if ($_POST["submit"] == "submit" && (!file_exists($settings_file) || isset($_SESSION['user'])))
-
-if ($_POST["submit"] == "submit")
+// This should work now.
+if ($_POST["submit"] == "submit" && (!file_exists($settings_file) || isset($_SESSION['user'])))
 {
     // Get submitted setup values.
     $blog_email = $_POST["blog_email"];


### PR DESCRIPTION
Settings file existence and user session should be checked before allowing settings submission.

It should work now. Tested it several times.
