### PR TITLE
Update RewriteRule to pass in full URL vars

### DIFF
--- a/dropplets/config/submit-settings.php
+++ b/dropplets/config/submit-settings.php
@@ -80,7 +80,7 @@ if ($_POST["submit"] == "submit")
         $htaccess[] = "RewriteEngine on";
         $htaccess[] = "RewriteCond %{REQUEST_URI} !index";
         $htaccess[] = "RewriteCond %{REQUEST_FILENAME} !-f";
-        $htaccess[] = "RewriteRule ^(.*)$ index.php?filename=$1 [L]";
+        $htaccess[] = "RewriteRule ^(.*)$ index.php?filename=$1 [NC,QSA,L]";
     
         // Generate the .htaccess file.
         file_put_contents($htaccess_file, implode("\n", $htaccess));


### PR DESCRIPTION
So Dropplets pages properly handle stuff like /search?q=keyword&start=1

http://httpd.apache.org/docs/2.2/rewrite/flags.html#flag_qsa
