### PR TITLE
Resume session in publish script

### DIFF
--- a/dashboard/publish.php
+++ b/dashboard/publish.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 
 // Get existing config.
 include('../dropplets/config/config-settings.php');


### PR DESCRIPTION
Publish script was resulting in an exit status of "Unauthorized access" as $_SESSION['user'] was not set.  As a result, drag and drop uploads would not publish.  Problem reproducible with MAMP/PHP 5.3.14/Chrome 27

Resuming session with session_start() seems to fix this problem.
