### PR TITLE
Some .htaccess fixes

### DIFF
--- a/dropplets/config/submit-settings.php
+++ b/dropplets/config/submit-settings.php
@@ -87,9 +87,8 @@ if ($_POST["submit"] == "submit" && (!file_exists($settings_file) || isset($_SES
         $htaccess[] = "RewriteRule ^(images)($|/) - [L]";
         $htaccess[] = "Options +FollowSymLinks -MultiViews";
         $htaccess[] = "RewriteEngine on";
-        if (strlen($dir) > 1)
-            $htaccess[] = "RewriteBase " . $dir;
-        $htaccess[] = "RewriteCond %{REQUEST_URI} !index";
+        $htaccess[] = "RewriteBase " . $dir;
+        $htaccess[] = "RewriteCond %{REQUEST_URI} !index\.php";
         $htaccess[] = "RewriteCond %{REQUEST_FILENAME} !-f";
         $htaccess[] = "RewriteRule ^(.*)$ index.php?filename=$1 [L]";
     


### PR DESCRIPTION
Here a small change I had to do to dropplets, to be able to install it at 2 web-hosters where I need to live with the default values for apache I get and .htaccess is the only thing I can configure. Still it shouldn't break any normal hostings I believe, since the difference is only, if default values don't match with what you expected before.

.....
The auto-generated .htaccess-file now always adds a RewriteBase and defines
a more strict rule for index to be index.php
This solves the problems by 2 web-hosts I've had were RewriteBase was required
even it was set to the root (/) and the default file wasn't index.php => it
worked only when set directly to "domain.tld/index.php" but not to "domain.tld"
