### PR TITLE
Theme 'simple' ajax fix

### DIFF
--- a/templates/simple/index.php
+++ b/templates/simple/index.php
@@ -39,7 +39,7 @@
             $(function() {
                 function load_next_page() {
                     $.ajax({
-                        url: "?page=" + next_page,
+                        url: "index.php?page=" + next_page,
                         success: function (res) {
                             next_page++;
                             var result = $.parseHTML(res);


### PR DESCRIPTION
Due to `.htaccess` configuration, a GET request with URL `http://path/to/dropplets/?page=2` will not pass the query to `index.php`. URL `http://path/to/dropplets/index.php?page=2` works well.
