### PR TITLE
Scrollbar fix (UPDATED)

### DIFF
--- a/dropplets/tools.php
+++ b/dropplets/tools.php
@@ -234,7 +234,7 @@ if (!isset($_SESSION['user'])) { ?>
             var myelement = $(this).attr("href")
             $(myelement).animate({left:"-300px"}, 200);
             $.cookies.set('dp-panel', 'closed');
-            $("body").css({ overflowY: 'scroll' });
+            $("body").css({ overflowY: 'auto' });
             return false;
         });
         


### PR DESCRIPTION
This will prevent a horizontal scrollbar upon closing the Dropplets admin panel, yet still prevent scrolling of the `<body>` while the panel is open.
