### PR TITLE
Add bitly integration to dropplets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pxm
 .DS_Store
 .htaccess
+.project
 config.php
 verify.php
 posts/*.md

--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -418,3 +418,31 @@ function get_footer() { ?>
 <?php 
 
 }
+
+/*-----------------------------------------------------------------------------------*/
+/* Bitly Functions
+/*-----------------------------------------------------------------------------------*/
+
+/* returns the shortened url */
+function get_bitly_short_url($url,$login,$appkey,$format='txt') {
+	$connectURL = 'http://api.bit.ly/v3/shorten?login='.$login.'&apiKey='.$appkey.'&uri='.urlencode($url).'&format='.$format;
+	return curl_get_result($connectURL);
+}
+
+/* returns expanded url */
+function get_bitly_long_url($url,$login,$appkey,$format='txt') {
+	$connectURL = 'http://api.bit.ly/v3/expand?login='.$login.'&apiKey='.$appkey.'&shortUrl='.urlencode($url).'&format='.$format;
+	return curl_get_result($connectURL);
+}
+
+/* returns a result form url */
+function curl_get_result($url) {
+	$ch = curl_init();
+	$timeout = 5;
+	curl_setopt($ch,CURLOPT_URL,$url);
+	curl_setopt($ch,CURLOPT_RETURNTRANSFER,1);
+	curl_setopt($ch,CURLOPT_CONNECTTIMEOUT,$timeout);
+	$data = curl_exec($ch);
+	curl_close($ch);
+	return $data;
+}

--- a/dropplets/save.php
+++ b/dropplets/save.php
@@ -50,6 +50,12 @@ if ($_POST["submit"] == "submit" && (!file_exists($settings_file) || isset($_SES
     if (isset($_POST["intro_text"])) {
         $intro_text = $_POST["intro_text"];
     }
+	if (isset($_POST["bitly_un"])) {
+        $bitly_un = $_POST["bitly_un"];
+    }
+	if (isset($_POST["bitly_key"])) {
+        $bitly_key = $_POST["bitly_key"];
+    }
     if (isset($_POST["template"])) {
         $template = $_POST["template"];
     }
@@ -88,6 +94,8 @@ if ($_POST["submit"] == "submit" && (!file_exists($settings_file) || isset($_SES
     $config[] = settings_format("meta_description", $meta_description);
     $config[] = settings_format("intro_title", $intro_title);
     $config[] = settings_format("intro_text", $intro_text);
+	$config[] = settings_format("bitly_un", $bitly_un);
+	$config[] = settings_format("bitly_key", $bitly_key);
     $config[] = "\$password = '".$password."';";
     $config[] = settings_format("header_inject", $header_inject);
     $config[] = settings_format("footer_inject", $footer_inject);

--- a/dropplets/settings.php
+++ b/dropplets/settings.php
@@ -30,6 +30,8 @@ define('BLOG_TITLE', $blog_title);
 define('META_DESCRIPTION', $meta_description);
 define('INTRO_TITLE', $intro_title);
 define('INTRO_TEXT', $intro_text);
+define('BITLY_UN', $bitly_un);
+define('BITLY_KEY', $bitly_key);
 define('HEADER_INJECT', stripslashes($header_inject));
 define('FOOTER_INJECT', stripslashes($footer_inject));
 define('ACTIVE_TEMPLATE', $template);

--- a/dropplets/tools.php
+++ b/dropplets/tools.php
@@ -178,6 +178,32 @@ if (!isset($_SESSION['user'])) { ?>
             </div>
             
             <div class="dp-row">
+                <div class="dp-icon dp-icon-text"></div>
+                <div class="dp-content">Extras</div>                
+                <a class="dp-link dp-toggle" href="#dp-extras"></a>
+                <button class="dp-button dp-button-submit" type="submit" name="submit" value="submit">k</button>
+            </div>
+            
+            <div class="dp-sub-panel" id="dp-extras">
+            	<div class="dp-row dp-editable">
+                	<div class="dp-icon dp-icon-edit"></div>
+                    
+                	<div class="dp-content">
+                    	<label>Bitly Username</label>
+                    	<input type="text" name="bitly_un" id="bitly_un" value="<?php echo BITLY_UN; ?>">
+                	</div>
+            	</div>
+            	<div class="dp-row dp-editable">
+                	<div class="dp-icon dp-icon-edit"></div>
+                    
+                	<div class="dp-content">
+                    	<label>Bitly API Key</label>
+                    	<input type="text" name="bitly_key" id="bitly_key" value="<?php echo BITLY_KEY; ?>">
+                	</div>
+            	</div>
+            </div>
+            
+            <div class="dp-row">
                 <div class="dp-icon dp-icon-code"></div>
                 <div class="dp-content">Code Injection</div>                
                 <a class="dp-link dp-toggle" href="#dp-injection"></a>

--- a/index.php
+++ b/index.php
@@ -114,6 +114,13 @@ if ($filename==NULL) {
             } else {
                 $post_link = $blog_url.str_replace(FILE_EXT, '', $post['fname']);
             }
+			
+			// Get post short (bitly) link.
+			if ($bitly_un != "" or $bitly_key != "") {
+				$short_url = get_bitly_short_url($post_link,$bitly_un,$bitly_key);
+			} else {
+				$short_url = $post_link;
+			}
 
             // Get the post image url.
             $image = str_replace(array(FILE_EXT), '', POSTS_DIR.$post['fname']).'.jpg';
@@ -335,6 +342,13 @@ else {
 
         // Get the post link.
         $post_link = $blog_url.str_replace(array(FILE_EXT, POSTS_DIR), '', $filename);
+		
+		// Get post short (bitly) link.
+		if ($bitly_un != "" or $bitly_key != "") {
+			$short_url = get_bitly_short_url($post_link,$bitly_un,$bitly_key);
+		} else {
+			$short_url = $post_link;
+		}
 
         // Get the post image url.
         $image = str_replace(array(FILE_EXT), '', $filename).'.jpg';
@@ -451,6 +465,8 @@ else {
                 <textarea hidden name="meta_description" id="meta_description"></textarea>
                 <input hidden type="text" name="intro_title" id="intro_title" value="Welcome to Dropplets">
                 <textarea hidden name="intro_text" id="intro_text">In a flooded selection of overly complex solutions, Dropplets has been created in order to deliver a much needed alternative. There is something to be said about true simplicity in the design, development and management of a blog. By eliminating all of the unnecessary elements found in typical solutions, Dropplets can focus on pure design, typography and usability. Welcome to an easier way to blog.</textarea>
+                <input hidden type="text" name="bitly_un" id="bitly_un" value="">
+				<input hidden type="text" name="bitly_key" id="bitly_key" value="">
 
     		    <button type="submit" name="submit" value="submit">k</button>
     		</form>

--- a/templates/simple/post.php
+++ b/templates/simple/post.php
@@ -18,8 +18,8 @@
             <?php echo($post_content); ?>
 
             <ul class="actions">
-                <li><a class="button" href="https://twitter.com/intent/tweet?screen_name=<?php echo($post_author_twitter); ?>&text=Re:%20<?php echo($post_link); ?>%20" data-dnt="true">Comment on Twitter</a></li>
-                <li><a class="button" href="https://twitter.com/intent/tweet?text=&quot;<?php echo($post_title); ?>&quot;%20<?php echo($post_link); ?>%20via%20&#64;<?php echo($post_author_twitter); ?>" data-dnt="true">Share on Twitter</a></li>
+                <li><a class="button" href="https://twitter.com/intent/tweet?screen_name=<?php echo($post_author_twitter); ?>&text=Re:%20<?php echo($short_url); ?>%20" data-dnt="true">Comment on Twitter</a></li>
+                <li><a class="button" href="https://twitter.com/intent/tweet?text=&quot;<?php echo($post_title); ?>&quot;%20<?php echo($short_url); ?>%20via%20&#64;<?php echo($post_author_twitter); ?>" data-dnt="true">Share on Twitter</a></li>
                 <li><a class="button" href="<?php echo($blog_url); ?>">More Articles</a></li>
             </ul>
 


### PR DESCRIPTION
$short_url can be used in a theme in place of $post_link. It will automatically convert the $post_link to a bitly link if the bitly username and bitly api key are entered correctly in the settings. Otherwise it falls back to $post_link (or results in an incorrect information failure that is evident from the shared text) I have changed it in the "Share on Twitter" and "Comment on Twitter" in the default theme as an example.
