### PR TITLE
Updated PHP Pass

### DIFF
--- a/dropplets/includes/phpass.php
+++ b/dropplets/includes/phpass.php
@@ -2,7 +2,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.3 / genuine.
+# Version 0.4 / genuine.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.
@@ -48,7 +48,7 @@ class PasswordHash {
 	function get_random_bytes($count)
 	{
 		$output = '';
-		if (is_readable('/dev/urandom') &&
+		if (@is_readable('/dev/urandom') &&
 		    ($fh = @fopen('/dev/urandom', 'rb'))) {
 			$output = fread($fh, $count);
 			fclose($fh);


### PR DESCRIPTION
Updating PHP Pass fixed issues for anyone who is on a shared hosting
plan, such as MediaTemple. The user would enter their password and see
Dropplets display an error before becoming unusable.
