### PR TITLE
Alternate Port bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -423,12 +423,12 @@ else {
     $path = $_SERVER["REQUEST_URI"];
 
     // Check if running on alternate port.
-    if($protocol = "https://"){
-        if($port === 443)
+    if ($protocol === "https://") {
+        if ($port === 443)
             $url = $protocol . $domain;
         else
             $url = $protocol . $domain . ":" . $port;
-    } else {
+    } elseif ($protocol === "http://") {
         if ($port === 80)
             $url = $protocol . $domain;
         else


### PR DESCRIPTION
The current `index.php` wouldn't store in the `config.php` the port of where the installation was running. 

It would store in the `config.php` the following:

``` php
   $blog_url = "http://localhost/"; 
```

instead of 

``` php
   $blog_url = "http://localhost:8888/";
```

I got all of the components individually and added the port.

If the protocol is HTTP and it's running on port 80, it won't add the port. The same for HTTPS if it's running on 443.
