### PR TITLE
Fixing issue 227: re-defining '$templates' in count_premium_templates()

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -272,6 +272,9 @@ function get_premium_templates($type = 'all', $target = 'blank') {
 }
 
 function count_premium_templates($type = 'all') {
+
+    $templates = simplexml_load_file('http://dropplets.com/marketplace/templates-'. $type .'.xml');
+
     if($templates===FALSE) {
         // Feed not available.
     } else {


### PR DESCRIPTION
Defining $templates again in the count_premium_templates function allows the page to load properly even if the marketplace is down.

May not be the most elegant solution but it works.

https://github.com/circa75/dropplets/issues/227
