### PR TITLE
jquery include: use // instead of defining http or https (fixes #206)

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -354,7 +354,7 @@ function get_header() { ?>
 
 function get_footer() { ?>
     <!-- jQuery & Required Scripts -->
-    <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
     
     <?php if (PAGINATION_ON_OFF !== "off") { ?>
     <!-- Post Pagination -->


### PR DESCRIPTION
allow proper jquery loading for HTTPS only sites.
