### PR TITLE
addresses issue 263 by adding support for png and gif images for posts

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -186,6 +186,25 @@ function get_posts_for_category($category) {
 }
 
 /*-----------------------------------------------------------------------------------*/
+/* Get Image for a Post
+/*-----------------------------------------------------------------------------------*/
+function get_post_image_url($filename)
+{
+    global $blog_url;
+    $supportedFormats = array( "jpg", "png", "gif" );
+    $slug = pathinfo($filename, PATHINFO_FILENAME);
+
+    foreach($supportedFormats as $fmt)
+    {
+        $imgFile = sprintf("%s%s.%s", POSTS_DIR, $slug, $fmt);
+        if (file_exists($imgFile))
+            return sprintf("%s/%s.%s", "${blog_url}posts", $slug, $fmt);
+    }
+
+    return false;
+}
+
+/*-----------------------------------------------------------------------------------*/
 /* Post Pagination
 /*-----------------------------------------------------------------------------------*/
 

--- a/index.php
+++ b/index.php
@@ -116,14 +116,8 @@ if ($filename==NULL) {
             }
 
             // Get the post image url.
-            $image = str_replace(array(FILE_EXT), '', POSTS_DIR.$post['fname']).'.jpg';
+            $post_image = get_post_image_url( $post['fname'] ) ?: get_twitter_profile_img($post_author_twitter);
 
-            if (file_exists($image)) {
-                $post_image = $blog_url.str_replace(array(FILE_EXT, './'), '', POSTS_DIR.$post['fname']).'.jpg';
-            } else {
-                $post_image = get_twitter_profile_img($post_author_twitter);
-            }
-            
             if ($post_status == 'draft') continue;
 
             // Get the milti-post template file.
@@ -341,14 +335,8 @@ else {
         $post_link = $blog_url.str_replace(array(FILE_EXT, POSTS_DIR), '', $filename);
 
         // Get the post image url.
-        $image = str_replace(array(FILE_EXT), '', $filename).'.jpg';
+        $post_image = get_post_image_url($filename) ?: get_twitter_profile_img($post_author_twitter);
 
-        if (file_exists($image)) {
-            $post_image = $blog_url.str_replace(array(FILE_EXT, './'), '', $filename).'.jpg';
-        } else {
-            $post_image = get_twitter_profile_img($post_author_twitter);
-        }
-        
         // Get the post content
         $file_array = file($filename);
         


### PR DESCRIPTION
This change adds a function that makes three attempts at finding a post_image before giving up and falling back to the author_twitter image. The current preference order is jpg, png, gif; first one found wins.

This satisfies the feature request in issue #263; which was one I had myself.
