### PR TITLE
trimmed newlines from post title and content description meta tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -314,7 +314,7 @@ else {
         $post_title = str_replace(array("\n",'<h1>','</h1>'), '', $post_title);
 
         // Get the post intro.
-        $post_intro = htmlspecialchars($fcontents[7]);
+        $post_intro = htmlspecialchars(trim($fcontents[7]));
 
         // Get the post author.
         $post_author = str_replace(array("\n", '-'), '', $fcontents[1]);
@@ -350,20 +350,14 @@ else {
         }
         
         // Get the post content
-        $file_array = file($filename);
-        
-        unset($file_array[0]);
-        unset($file_array[1]);
-        unset($file_array[2]);
-        unset($file_array[3]);
-        unset($file_array[4]);
-        unset($file_array[5]);
-        unset($file_array[6]);
-        
-        $post_content = Markdown(implode("", $file_array));
+        $file_array = array_slice( file($filename), 7);
+        $post_content = Markdown(trim(implode("", $file_array)));
+
+        // free memory
+        unset($file_array);
                 
         // Get the site title.
-        $page_title = str_replace('# ', '', $fcontents[0]);
+        $page_title = trim(str_replace('# ', '', $fcontents[0]));
 
         // Generate the page description and author meta.
         $get_page_meta[] = '<meta name="description" content="' . $post_intro . '">';
@@ -387,7 +381,7 @@ else {
         $get_page_meta[] = '<meta property="og:image" content="' . $post_image . '">';
 
         // Generate all page meta.
-        $page_meta = implode("\n", $get_page_meta);
+        $page_meta = implode("\n\t", $get_page_meta);
 
         // Generate the post.
         $post = Markdown(join('', $fcontents));

--- a/templates/simple/index.php
+++ b/templates/simple/index.php
@@ -6,6 +6,7 @@
         <title><?php echo($page_title); ?></title>
         
         <?php echo($page_meta); ?>
+
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
         <link rel="stylesheet" href="<?php echo($template_dir_url); ?>style.css">


### PR DESCRIPTION
In an article view, the meta tags containing content pulled from the markdown would contain a newline at their end, causing `">` to appear separately on the next line in the source. A harmless side-effect, but one that's easily fixed. These changes trim whitespace from the offending content when generating the tags.

The meta tags now also align at a nicer indent level.
The empty line added to `templates/simple/index.php` is intentional, to align the last meta item added by the simple theme.
