### PR TITLE
Disable infinite load on single-post page

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -316,6 +316,8 @@ $currentpage .= $_SERVER["REQUEST_URI"];
 // If is home.
 $is_home = ($homepage==$currentpage);
 define('IS_HOME', $is_home);
+define('IS_CATEGORY', (bool)strstr($_SERVER['REQUEST_URI'], '/category/'));
+define('IS_SINGLE', !(IS_HOME || IS_CATEGORY));
 
 /*-----------------------------------------------------------------------------------*/
 /* Get Profile Image
@@ -324,7 +326,7 @@ define('IS_HOME', $is_home);
 function get_twitter_profile_img($username) {
 	
 	// Get the cached profile image.
-    $cache = (strstr($_SERVER['REQUEST_URI'], '/category/')) ? '.' : '';
+    $cache = IS_CATEGORY ? '.' : '';
     $array = split('/category/', $_SERVER['REQUEST_URI']);
     $array = split('/', $array[1]);
     if(count($array)!=1) $cache .= './.';
@@ -380,7 +382,7 @@ function get_footer() { ?>
     <!-- jQuery & Required Scripts -->
     <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
     
-    <?php if (PAGINATION_ON_OFF !== "off") { ?>
+    <?php if (!IS_SINGLE && PAGINATION_ON_OFF !== "off") { ?>
     <!-- Post Pagination -->
     <script>
         var infinite = true;


### PR DESCRIPTION
This pull-request can be debated.

Next posts are loaded on every page : 
- homepage
- category page
- single-post page

It should be nice to disable this load on the single-post page. 
- First, there's no reason to get every posts on this page (at best, only related ones, but this is another problem).
- Second, it can become a constraint for some themes. I'm thinking -for example- about getting a meta block with `position: fixed` : if we scroll under the post content, where the posts list was loaded, the block will be above the list. Sure it can be solved with a few CSS/JS, but it shouldn't be a problem first of all.
