### PR TITLE
Extra slash added to image path in simple template

### DIFF
--- a/templates/simple/post.php
+++ b/templates/simple/post.php
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="one-quarter meta">
             <div class="thumbnail">
-                <img src="/<?php echo($post_image); ?>" alt="<?php echo($post_title); ?>" />
+                <img src="<?php echo($post_image); ?>" alt="<?php echo($post_title); ?>" />
             </div>
 
             <ul>

--- a/templates/simple/posts.php
+++ b/templates/simple/posts.php
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="one-quarter meta">
             <div class="thumbnail">
-                <img src="/<?php echo($post_image); ?>" alt="<?php echo($post_title); ?>" />
+                <img src="<?php echo($post_image); ?>" alt="<?php echo($post_title); ?>" />
             </div>
 
             <ul>


### PR DESCRIPTION
Fix for a code regression where the template was updated to prepend a
"/" infront of the image path.  Fixes image display on Firefox and
Safari.

This addresses issue #279
