### PR TITLE
Fixing installer error on password save. $dir not defined, so defining i...

### DIFF
--- a/dropplets/save.php
+++ b/dropplets/save.php
@@ -6,6 +6,7 @@ session_start();
 $settings_file = "../config.php";
 $htaccess_file = "../.htaccess";
 $phpass_file   = '../dropplets/includes/phpass.php';
+$dir = '';
 
 // Get existing settings.
 if (file_exists($settings_file)) {


### PR DESCRIPTION
...t at the top of the file.
