### PR TITLE
Fallback for infinite load failures, and minor fixes.

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -408,7 +408,7 @@ function get_footer() { ?>
                             no_more_posts = true;
                         }  else {
                             $('.loading-frame').remove();
-                            $('body').append(articles.slice(1));
+                            $('body').append(articles);
                         }
                         loading = false;
                     },


### PR DESCRIPTION
## 1/ Fallback for infinite load failures

In case infinite load fail, we remove the loading gif, an show an error message.
We must not set `loading = true`, or multiple loads will occurs (and multiple error messages be added)
## 2/ Ending message when the end of a list is reached

To ensure user is warned.
## 3/ Bug fix - Some articles aren't rendered

With infinite load, the first article is never shown.
