### PR TITLE
Changed to make the $is_home determination on URI instead of the whole U...

### DIFF
--- a/dropplets/functions.php
+++ b/dropplets/functions.php
@@ -307,11 +307,10 @@ function count_premium_templates($type = 'all') {
 /* If is Home (Could use "is_single", "is_category" as well.)
 /*-----------------------------------------------------------------------------------*/
 
-$homepage = BLOG_URL;
+$homepage = parse_url(BLOG_URL, PHP_URL_PATH);
 
 // Get the current page.    
-$currentpage  = @( $_SERVER["HTTPS"] != 'on' ) ? 'http://'.$_SERVER["SERVER_NAME"] : 'https://'.$_SERVER["SERVER_NAME"];
-$currentpage .= $_SERVER["REQUEST_URI"];
+$currentpage  = $_SERVER["REQUEST_URI"];
 
 // If is home.
 $is_home = ($homepage==$currentpage);


### PR DESCRIPTION
I noticed that the $is_home variable was doing a comparison based on a generated server URL, which was not working as expected when running Apache on a non-standard port (8080 in my case). Instead, I changed the comparison logic to be based solely on the URI instead of the full URL.

In reviewing the bugs, I think this might resolve issue #294. 

Thanks for providing such a useful tool.

Cheers,

Daniel James
